### PR TITLE
Fix typo in verdict message

### DIFF
--- a/core/pe_analyzer.c
+++ b/core/pe_analyzer.c
@@ -350,7 +350,7 @@ VOID evaluate_threats(PIMAGE_NT_HEADERS p_nt_header, LPVOID lp_base_address, Ana
         sprintf(result->verdict, "Low risk");
     }
     else {
-        sprintf(result->verdict, "Clen");
+        sprintf(result->verdict, "Clean");
     }
     
     


### PR DESCRIPTION
Corrected 'Clen' to 'Clean' in the verdict output of the evaluate_threats function.